### PR TITLE
fix: improve graceful shutdown sequence

### DIFF
--- a/internal/client/module.go
+++ b/internal/client/module.go
@@ -131,11 +131,27 @@ func Module(
 					// Wait for client to finish with timeout
 					select {
 					case err := <-clientDone:
-						if errors.Is(err, context.Canceled) {
+						if !errors.Is(err, context.Canceled) {
 							l.Errorf("client error during shutdown: %v", err)
 						}
 					case <-time.After(30 * time.Second):
-						l.Error("timeout waiting for client to stop")
+						l.WithFields(map[string]any{
+							"waiting_tasks":    client.workerPool.WaitingTasks(),
+							"running_workers":  client.workerPool.RunningWorkers(),
+						}).Error("timeout waiting for client to stop, forcing shutdown")
+
+						// Record timeout metric
+						client.metricsRegistry.ShutdownTimeouts().Add(context.Background(), 1)
+
+						// Force stop worker pool
+						client.workerPool.Stop()
+
+						// Force close gRPC connection
+						if client.grpcConn != nil {
+							if err := client.grpcConn.Close(); err != nil {
+								l.Errorf("error force closing grpc connection: %v", err)
+							}
+						}
 					}
 
 					authInterceptor.Close()

--- a/internal/grpcmetrics/metrics.go
+++ b/internal/grpcmetrics/metrics.go
@@ -11,6 +11,7 @@ type MetricsRegistry interface {
 	ServerMessageReceivedByType() metric.Int64Counter
 	ConnectionRetries() metric.Int64Counter
 	ConnectionStatus() metric.Int64UpDownCounter
+	ShutdownTimeouts() metric.Int64Counter
 }
 
 type metricsRegistry struct {
@@ -19,6 +20,7 @@ type metricsRegistry struct {
 	serverMessageReceivedByType metric.Int64Counter
 	connectionRetries           metric.Int64Counter
 	connectionStatus            metric.Int64UpDownCounter
+	shutdownTimeouts            metric.Int64Counter
 }
 
 func RegisterMetricsRegistry(meterProvider metric.MeterProvider) (MetricsRegistry, error) {
@@ -69,12 +71,22 @@ func RegisterMetricsRegistry(meterProvider metric.MeterProvider) (MetricsRegistr
 		return nil, err
 	}
 
+	shutdownTimeouts, err := meter.Int64Counter(
+		"shutdown_timeouts_total",
+		metric.WithUnit("1"),
+		metric.WithDescription("Total number of shutdown timeout occurrences"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &metricsRegistry{
 		httpCallLatencies:           httpCallLatencies,
 		httpCallStatusCodes:         httpCallStatusCodes,
 		serverMessageReceivedByType: serverMessageReceivedByType,
 		connectionRetries:           connectionRetries,
 		connectionStatus:            connectionStatus,
+		shutdownTimeouts:            shutdownTimeouts,
 	}, nil
 }
 
@@ -96,6 +108,10 @@ func (m *metricsRegistry) ConnectionRetries() metric.Int64Counter {
 
 func (m *metricsRegistry) ConnectionStatus() metric.Int64UpDownCounter {
 	return m.connectionStatus
+}
+
+func (m *metricsRegistry) ShutdownTimeouts() metric.Int64Counter {
+	return m.shutdownTimeouts
 }
 
 type NoOpMetricsRegistry struct{}
@@ -126,5 +142,10 @@ func (m *NoOpMetricsRegistry) ConnectionRetries() metric.Int64Counter {
 
 func (m *NoOpMetricsRegistry) ConnectionStatus() metric.Int64UpDownCounter {
 	counter, _ := otel.GetMeterProvider().Meter("client").Int64UpDownCounter("connection_status")
+	return counter
+}
+
+func (m *NoOpMetricsRegistry) ShutdownTimeouts() metric.Int64Counter {
+	counter, _ := otel.GetMeterProvider().Meter("client").Int64Counter("shutdown_timeouts_total")
 	return counter
 }


### PR DESCRIPTION
## Summary
Improve graceful shutdown to prevent indefinite hangs when tasks don't complete within timeout.

## Changes
- Add `shutdown_timeouts_total` metric to track shutdown timeout occurrences
- Log task statistics (waiting tasks, running workers) when shutdown timeout occurs
- Force stop worker pool after 30 second grace period
- Force close gRPC connection after timeout to ensure cleanup
- Fix error logging logic (was incorrectly logging canceled errors)
- Add structured logging for shutdown timeout diagnostics

## Impact
Previously, if tasks were stuck or slow to complete, the application could hang indefinitely during shutdown. Now:
1. Grace period of 30 seconds for clean shutdown
2. Force termination after timeout with detailed logging
3. Metrics tracking for monitoring shutdown health
4. Guaranteed connection cleanup

This ensures the application can always shut down, even under failure conditions, while providing visibility into any issues.

## Related Issue
Fixes item #13 in TODOS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)